### PR TITLE
Escape minimum necessary characters

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+.gitattributes export-ignore
+.gitignore export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+phpunit.xml.dist export-ignore
+tests/ export-ignore

--- a/add-admin-css.php
+++ b/add-admin-css.php
@@ -624,7 +624,7 @@ HTML;
 
 		if ( $css ) {
 			echo "<style>\n";
-			echo esc_html( $css ) . "\n";
+			echo str_replace( '<', '&lt;', wp_check_invalid_utf8( $css ) ) . "\n";
 			echo "</style>\n";
 		}
 	}


### PR DESCRIPTION
Fixes #3

Applies the suggestion I mentioned in #3. Feel free to discard.

The .gitattributes file I created to grab a ZIP off GitHub also came along because I added it to the same branch.